### PR TITLE
chore: Add helper funcs

### DIFF
--- a/fillers/messages.js
+++ b/fillers/messages.js
@@ -50,6 +50,6 @@ module.exports = async db => {
 		}
 	}
 
-	processMissingElements(collection, bulkOperations.length, bulkOperations);
+	processMissingElements(collection, totalElements, bulkOperations);
 };
 

--- a/fillers/messages.js
+++ b/fillers/messages.js
@@ -1,4 +1,5 @@
 const {faker} = require('@faker-js/faker');
+const {writeBatch, processMissingElements} = require('../helpers/write');
 
 function generateMessage() {
 	const ts = faker.date.between({
@@ -41,19 +42,14 @@ module.exports = async db => {
 				document: generateMessage(),
 			},
 		});
+
 		if (bulkOperations.length >= batch) {
 			// eslint-disable-next-line no-await-in-loop
-			const r = await collection.bulkWrite(bulkOperations);
-			console.dir({
-				batch: r.insertedCount,
-				total: totalElements,
-				remaining: totalElements - i,
-				ok: r.isOk(),
-				errors: r.hasWriteErrors(),
-				errorList: r.getWriteErrors(),
-			});
+			await writeBatch(collection, totalElements, bulkOperations, i);
 			bulkOperations.length = 0;
 		}
 	}
+
+	processMissingElements(collection, bulkOperations.length, bulkOperations);
 };
 

--- a/fillers/users.js
+++ b/fillers/users.js
@@ -95,8 +95,8 @@ module.exports = async db => {
 	}
 
 	await Promise.all([
-		processMissingElements(users, bulkOperations.length, bulkOperations),
-		processMissingElements(subs, subsBulkOperations.length, subsBulkOperations),
+		processMissingElements(users, totalElements, bulkOperations),
+		processMissingElements(subs, totalElements, subsBulkOperations),
 	]);
 };
 

--- a/fillers/users.js
+++ b/fillers/users.js
@@ -1,4 +1,5 @@
 const {faker} = require('@faker-js/faker');
+const {writeBatch, processMissingElements} = require('../helpers/write');
 
 function generateUser() {
 	return {
@@ -58,7 +59,7 @@ function generateSubscription(userId, username) {
 }
 
 module.exports = async db => {
-	const collection = db.collection('users');
+	const users = db.collection('users');
 	const subs = db.collection('rocketchat_subscription');
 
 	const bulkOperations = [];
@@ -74,70 +75,28 @@ module.exports = async db => {
 			},
 		});
 
-		const sub = generateSubscription(user._id, user.username);
 		subsBulkOperations.push({
 			insertOne: {
-				document: sub,
+				document: generateSubscription(user._id, user.username),
 			},
 		});
 
 		if (bulkOperations.length >= batch) {
 			// eslint-disable-next-line no-await-in-loop
-			const r = await collection.bulkWrite(bulkOperations);
-			console.dir({
-				action: 'users',
-				batch: r.insertedCount,
-				total: totalElements,
-				remaining: totalElements - i,
-				ok: r.isOk(),
-				errors: r.hasWriteErrors(),
-				errorList: r.getWriteErrors(),
-			});
+			await writeBatch(users, totalElements, bulkOperations, i);
 			bulkOperations.length = 0;
 		}
 
 		if (subsBulkOperations.length >= batch) {
 			// eslint-disable-next-line no-await-in-loop
-			const r = await subs.bulkWrite(subsBulkOperations);
-			console.dir({
-				action: 'subscriptions',
-				batch: r.insertedCount,
-				total: totalElements,
-				remaining: totalElements - i,
-				ok: r.isOk(),
-				errors: r.hasWriteErrors(),
-				errorList: r.getWriteErrors(),
-			});
+			await writeBatch(subs, totalElements, subsBulkOperations, i);
 			subsBulkOperations.length = 0;
 		}
 	}
 
-	if (bulkOperations.length >= 0) {
-		const r = await collection.bulkWrite(bulkOperations);
-		console.dir({
-			action: 'users',
-			batch: r.insertedCount,
-			total: totalElements,
-			remaining: bulkOperations.length,
-			ok: r.isOk(),
-			errors: r.hasWriteErrors(),
-			errorList: r.getWriteErrors(),
-		});
-		bulkOperations.length = 0;
-	}
-
-	if (subsBulkOperations.length >= 0) {
-		const r = await subs.bulkWrite(subsBulkOperations);
-		console.dir({
-			action: 'subscriptions',
-			batch: r.insertedCount,
-			total: totalElements,
-			remaining: subsBulkOperations.length,
-			ok: r.isOk(),
-			errors: r.hasWriteErrors(),
-			errorList: r.getWriteErrors(),
-		});
-		subsBulkOperations.length = 0;
-	}
+	await Promise.all([
+		processMissingElements(users, bulkOperations.length, bulkOperations),
+		processMissingElements(subs, subsBulkOperations.length, subsBulkOperations),
+	]);
 };
 

--- a/helpers/db.js
+++ b/helpers/db.js
@@ -1,0 +1,12 @@
+const {MongoClient} = require('mongodb');
+
+const defaultDbUri = 'mongodb://localhost:3001/';
+const defaultDbName = 'meteor';
+
+function connect(uri = defaultDbUri, dbName = defaultDbName) {
+	return new MongoClient(uri).db(dbName);
+}
+
+module.exports = {
+	connect,
+};

--- a/helpers/write.js
+++ b/helpers/write.js
@@ -26,7 +26,8 @@ async function writeBatch(collection, totalElements, docs, currentIterationParam
 
 async function processMissingElements(collection, totalElements, docs) {
 	if (docs.length > 0) {
-		await writeBatch(collection, totalElements, docs);
+		// Infinity is passed here to assure `remaining` will be printed as 0 when this is called
+		await writeBatch(collection, totalElements, docs, Number.POSITIVE_INFINITY);
 	}
 }
 

--- a/helpers/write.js
+++ b/helpers/write.js
@@ -1,0 +1,36 @@
+function getIterationNumberFromBatchSize(batchSize, currentIteration) {
+	if (typeof currentIteration !== 'number') {
+		return 0;
+	}
+
+	return Math.abs((batchSize - (currentIteration + 1)) / batchSize) + 1;
+}
+
+async function writeBatch(collection, totalElements, docs, currentIterationParam) {
+	const colName = collection.collectionName;
+	const currentIteration = getIterationNumberFromBatchSize(docs.length, currentIterationParam);
+	console.log(`Processing batch of size ${docs.length} - ${colName}. Iteration ${currentIteration}`);
+
+	const r = await collection.bulkWrite(docs);
+
+	console.dir({
+		action: colName,
+		batchSize: r.insertedCount,
+		total: totalElements,
+		ok: r.isOk(),
+		errors: r.hasWriteErrors(),
+		...(r.hasWriteErrors() && {writeErrors: r.getWriteErrors()}),
+		...(currentIteration !== 0 && {remaining: totalElements - ((currentIteration) * docs.length)}),
+	});
+}
+
+async function processMissingElements(collection, totalElements, docs) {
+	if (docs.length > 0) {
+		await writeBatch(collection, totalElements, docs);
+	}
+}
+
+module.exports = {
+	writeBatch,
+	processMissingElements,
+};

--- a/index.js
+++ b/index.js
@@ -1,18 +1,15 @@
-const {MongoClient} = require('mongodb');
 const fs = require('fs');
 const path = require('path');
-
-const uri = 'mongodb://localhost:3001/';
-const client = new MongoClient(process.env.MONGO_URI || uri);
-
-if (process.argv.length < 2) {
-	console.error('Missing target collection');
-	process.exit(1);
-}
+const {connect} = require('./helpers/db');
 
 async function fill() {
 	const col = process.argv[2];
-	const db = client.db(process.env.DB || 'meteor');
+	if (process.argv.length < 2) {
+		console.error('Missing target collection');
+		process.exit(1);
+	}
+
+	const db = connect(process.env.MONGO_URI, process.env.DB);
 
 	const availableFillers = fs.readdirSync(`${__dirname}/fillers`).map(file => path.basename(file, '.js'));
 	if (!availableFillers.includes(col.toLowerCase())) {
@@ -22,13 +19,13 @@ async function fill() {
 
 	const filler = require(`./fillers/${col}`);
 
-	console.log(`Filling ${col}`);
+	console.log(`Filling database using "${col}" script`);
 	return filler(db);
 }
 
 fill()
 	.then(() => {
-		console.log('Done filling');
+		console.log(`Done filling ${process.argv[2]}`);
 		process.exit(0);
 	})
 	.catch(err => {

--- a/index.js
+++ b/index.js
@@ -21,12 +21,14 @@ async function fill() {
 	}
 
 	const filler = require(`./fillers/${col}`);
+
+	console.log(`Filling ${col}`);
 	return filler(db);
 }
 
 fill()
 	.then(() => {
-		console.log('done');
+		console.log('Done filling');
 		process.exit(0);
 	})
 	.catch(err => {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "lint": "eslint ."
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Adds 2 new funcs:

`writeBatch` - takes the collection, batch size & operations as arguments and writes them to the DB usign `bulkWrite`. Mainly for hiding the process of logging the results & simplifying the code
`processMissingElements` - calls `writeBatch` internally if the operations array is greater than 0 (elements missing from the regular loop)

- Smol changes on the `index` file to make it prettier and better logs
- Adds `yarn lint` command