### PR TITLE
fix: Missing batch elements in messages filler are not inserted in the DB

### DIFF
--- a/fillers/messages.js
+++ b/fillers/messages.js
@@ -50,6 +50,6 @@ module.exports = async db => {
 		}
 	}
 
-	processMissingElements(collection, totalElements, bulkOperations);
+	await processMissingElements(collection, totalElements, bulkOperations);
 };
 


### PR DESCRIPTION
# Proposed changes
We're missing an await when inserting missing elements in the messages filter (so in case the user tries to insert less than 1000 messages, nothing would happen and no message would be included in the DB). Currently, only multiples of 1000 messages are included in the DB (the remaining ones are missing).