### PR TITLE
feat: Add contacts filler

### DIFF
--- a/fillers/contacts.js
+++ b/fillers/contacts.js
@@ -1,0 +1,97 @@
+const {faker} = require('@faker-js/faker');
+const {writeBatch, processMissingElements} = require('../helpers/write');
+
+function generateContactChannel() {
+	const sourceType = faker.helpers.arrayElement(['widget', 'email', 'sms', 'app', 'api']);
+	const sourceId = faker.git.commitSha({length: 25});
+	const verified = faker.datatype.boolean();
+	return {
+		name: faker.helpers.arrayElement(['widget', 'email', 'sms', 'app', 'api']),
+		verified,
+		visitor: {
+			visitorId: faker.git.commitSha({length: 25}),
+			source: {type: sourceType, ...(sourceType === 'app' && {id: sourceId})},
+		},
+		blocked: faker.datatype.boolean(),
+		details: {
+			type: sourceType,
+			...(sourceType === 'app' && {id: sourceId}),
+			label: faker.word.noun(),
+			alias: faker.word.noun(),
+		},
+		...(verified && {verifiedAt: faker.date.recent()}),
+		...(faker.datatype.boolean() && {
+			lastChat: {
+				_id: faker.git.commitSha({length: 25}),
+				ts: faker.date.recent(),
+			},
+		}),
+	};
+}
+
+function generatePhone() {
+	return {phoneNumber: faker.phone.number()};
+}
+
+function generateEmail() {
+	return {address: faker.internet.email()};
+}
+
+function generateConflictingFields() {
+	return {field: faker.helpers.arrayElement(['name', 'manager', `customFields.${faker.word.noun()}`]), value: faker.word.noun()};
+}
+
+function generateContact() {
+	return {
+		_id: faker.git.commitSha({length: 25}),
+		_updatedAt: new Date(),
+		name: faker.person.fullName(),
+		phones: Array(faker.number.int(parseInt(process.env.MAX_PHONES, 10))).fill(undefined).map(() => generatePhone()),
+		emails: Array(faker.number.int(parseInt(process.env.MAX_EMAILS, 10))).fill(undefined).map(() => generateEmail()),
+		contactManager: faker.git.commitSha({length: 25}),
+		unknown: faker.datatype.boolean(),
+		conflictingFields: faker.datatype.boolean() ? Array(faker.number.int(parseInt(process.env.MAX_CONFLICTING_FIELDS, 10))).fill(undefined).map(() => generateConflictingFields()) : [],
+		customFields: Object.fromEntries(Array(faker.number.int(parseInt(process.env.MAX_CUSTOM_FIELDS, 10))).fill(undefined).map(() => [faker.word.noun(), faker.word.noun()])),
+		channels: Array(faker.number.int(parseInt(process.env.MAX_CHANNELS, 10))).fill(undefined).map(() => generateContactChannel()),
+		createdAt: faker.date.recent(),
+		...(faker.datatype.boolean() && {
+			lastChat: {
+				_id: faker.git.commitSha({length: 25}),
+				ts: faker.date.recent(),
+			},
+		}),
+		preRegistration: true,
+	};
+}
+
+function validateEnv() {
+	if ((!process.env.MAX_PHONES || !process.env.MAX_EMAILS || !process.env.MAX_CONFLICTING_FIELDS || !process.env.MAX_CHANNELS || !process.env.MAX_CUSTOM_FIELDS)) {
+		throw new Error('Missing env variables');
+	}
+}
+
+module.exports = async db => {
+	validateEnv();
+	const collection = db.collection('rocketchat_livechat_contact');
+
+	const bulkOperations = [];
+	const batch = 1000;
+	const totalElements = parseInt(process.env.CONTACTS, 10) || 10000;
+
+	for (let i = 0; i < totalElements; i++) {
+		bulkOperations.push({
+			insertOne: {
+				document: generateContact(),
+			},
+		});
+
+		if (bulkOperations.length >= batch) {
+			// eslint-disable-next-line no-await-in-loop
+			await writeBatch(collection, totalElements, bulkOperations, i);
+			bulkOperations.length = 0;
+		}
+	}
+
+	await processMissingElements(collection, totalElements, bulkOperations);
+};
+


### PR DESCRIPTION
# Proposed changes
- Add a new filler to create contacts in the `rocketchat_livechat_contact` collection.

**Expected env vars:**
- `MAX_PHONES`: maximum amount of phones a contact can have. For each contact, the amount of phones is chosen randomly in the interval `[0, MAX_PHONES]`;
- `MAX_EMAILS`: maximum amount of e-mails a contact can have. For each contact, the amount of e-mails is chosen randomly in the interval `[0, MAX_EMAILS]`;
- `MAX_CONFLICTING_FIELDS`: maximum amount of conflicting fields a contact can have. For each contact, the amount of conflicting fields is chosen randomly in the interval `[0, MAX_CONFLICTING_FIELDS]`. Each conflicting field is also created randomly using a random word as a key (which can be `name`, `manager` or `customFields.<a-random-word>`) and another random word as a value;
- `MAX_CHANNELS`: maximum amount of channels a contact can have. For each contact, the amount of channels is chosen randomly in the interval `[0, MAX_CHANNELS]`. Each contact channel is created using random data;
- `MAX_CUSTOM_FIELDS`: maximum amount of custom fields a contact can have. For each contact, the amount of custom fields is chosen randomly in the interval `[0, MAX_CUSTOM_FIELDS]`. Each custom field is also created randomly using a random word as a key and another random word as a value;

# Schemas
I followed [these interfaces/schemas](https://github.com/RocketChat/Rocket.Chat/blob/2c2a35af24d4e1d0305cf134bf1e157da91a30c5/packages/core-typings/src/ILivechatContact.ts) to create the random data for contacts:
